### PR TITLE
Nova migration/Inserção de coluna telefone no banco

### DIFF
--- a/src/main/java/med/voll/api/controller/MedicoController.java
+++ b/src/main/java/med/voll/api/controller/MedicoController.java
@@ -1,5 +1,6 @@
 package med.voll.api.controller;
 
+import jakarta.validation.Valid;
 import med.voll.api.medico.DadosCadastroMedico;
 import med.voll.api.medico.Medico;
 import med.voll.api.medico.MedicoRepository;
@@ -19,7 +20,7 @@ public class MedicoController {
 
     @PostMapping
     @Transactional
-    public void cadastrar(@RequestBody DadosCadastroMedico dados){
+    public void cadastrar(@RequestBody @Valid DadosCadastroMedico dados){
         repository.save(new Medico(dados));
     }
 }

--- a/src/main/java/med/voll/api/endereco/DadosEndereco.java
+++ b/src/main/java/med/voll/api/endereco/DadosEndereco.java
@@ -1,4 +1,20 @@
 package med.voll.api.endereco;
 
-public record DadosEndereco(String logradouro, String bairro, String cep, String cidade, String uf, String complemento, String numero) {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record DadosEndereco(
+        @NotBlank
+        String logradouro,
+        @NotBlank
+        String bairro,
+        @NotBlank
+        @Pattern(regexp = "\\d{8}")
+        String cep,
+        @NotBlank
+        String cidade,
+        @NotBlank
+        String uf,
+        String complemento,
+        String numero) {
 }

--- a/src/main/java/med/voll/api/medico/DadosCadastroMedico.java
+++ b/src/main/java/med/voll/api/medico/DadosCadastroMedico.java
@@ -1,6 +1,30 @@
 package med.voll.api.medico;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import med.voll.api.endereco.DadosEndereco;
 
-public record DadosCadastroMedico(String nome, String email, String crm, Especialidade especialidade, DadosEndereco endereco) {
+public record DadosCadastroMedico(
+        @NotBlank
+        String nome,
+
+        @NotBlank
+        @Email
+        String email,
+
+        @NotBlank
+        String telefone,
+
+        @NotBlank
+        @Pattern(regexp = "\\d{4,6}")
+        String crm,
+
+        @NotNull
+        Especialidade especialidade,
+
+        @NotNull @Valid
+        DadosEndereco endereco) {
 }

--- a/src/main/java/med/voll/api/medico/Especialidade.java
+++ b/src/main/java/med/voll/api/medico/Especialidade.java
@@ -5,5 +5,6 @@ public enum Especialidade {
     ORTOPEDIA,
     CARDIOLOGIA,
     GINECOLOGIA,
-    DERMATOLOGIA;
+    DERMATOLOGIA,
+    PSIQUIATRA;
 }

--- a/src/main/java/med/voll/api/medico/Medico.java
+++ b/src/main/java/med/voll/api/medico/Medico.java
@@ -20,6 +20,7 @@ public class Medico {
     private String nome;
     private String email;
     private String crm;
+    private String telefone;
 
     @Enumerated(EnumType.STRING)
     private Especialidade especialidade;
@@ -31,6 +32,7 @@ public class Medico {
         this.nome = dados.nome();
         this.email = dados.email();
         this.crm = dados.crm();
+        this.telefone = dados.telefone();
         this.especialidade = dados.especialidade();
         this.endereco = new Endereco(dados.endereco());
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+spring.flyway.repair-enabled=true
 spring.application.name=api
 spring.datasource.url=jdbc:mysql://localhost/vollmed_api
 spring.datasource.username=root

--- a/src/main/resources/db/migration/V2__alter-table-medicos-add-column-telefone.sql
+++ b/src/main/resources/db/migration/V2__alter-table-medicos-add-column-telefone.sql
@@ -1,0 +1,1 @@
+alter table medicos add telefone varchar(20) not null;


### PR DESCRIPTION
Esta PR adiciona uma nova migration ao projeto, responsável por inserir a coluna `telefone` na tabela `medicos`.

### Alterações realizadas:
- Criada migration `V2__alter-table-medicos-add-column-telefone.sql`
- Atualização da estrutura da tabela `medicos` para incluir o campo `telefone`

### Objetivo:
Permitir o armazenamento do telefone dos médicos diretamente no banco de dados, preparando o sistema para suportar essa nova informação nas operações de cadastro e consulta.

---
